### PR TITLE
Add caching support for Docker builds in GitHub Actions

### DIFF
--- a/.github/workflows/BuildDockerImage.yml
+++ b/.github/workflows/BuildDockerImage.yml
@@ -38,5 +38,7 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/PublishDockerImage.yml
+++ b/.github/workflows/PublishDockerImage.yml
@@ -55,6 +55,8 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 


### PR DESCRIPTION
So I thought the action would automatically do this. It doesn't.

See their own CI workflow:

https://github.com/docker/build-push-action/blob/9e436ba9f2d7bcd1d038c8e55d039d37896ddc5d/.github/workflows/ci.yml#L551-L560